### PR TITLE
single-c: use `gcc -fanalyzer` to increase coverage

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -28,8 +28,9 @@ jobs:
 
       - name: Enable given copr repositories
         run: |
-          dnf copr enable lzaoral/Divine -y
-          dnf copr enable kdudka/predator -y
+          dnf copr enable -y lzaoral/Divine
+          dnf copr enable -y kdudka/csdiff
+          dnf copr enable -y kdudka/predator
           if [[ ! -v NO_SYMBIOTIC ]]; then
             dnf copr enable jamartis/symbiotic -y
           fi

--- a/tests/find-tools.cmake
+++ b/tests/find-tools.cmake
@@ -37,7 +37,7 @@ set(TOOL_EXEC_predator "${TOOL_EXEC_gcc} -fplugin=predator"
 set(gcc_min_version 11)
 
 # command that returns major version number of the specified gcc executable
-set (gcc_version_cmd "echo __GNUC__ | ${TOOL_EXEC_gcc} -E - | tail -1")
+set(gcc_version_cmd "echo __GNUC__ | ${TOOL_EXEC_gcc} -E - | tail -1")
 
 # probe for available static analyzers and formal verification tools
 append_tool_on_succ(gcc        "test ${gcc_min_version} -le \$(${gcc_version_cmd})")

--- a/tests/single-c/args-prefix@gcc
+++ b/tests/single-c/args-prefix@gcc
@@ -1,1 +1,1 @@
--c
+-fanalyzer -fdiagnostics-path-format=separate-events -fno-diagnostics-show-caret -c

--- a/tests/single-c/mem-basic-calloc/0002-calloc-doublefree/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0002-calloc-doublefree/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./0002-test.c: scope_hint: In function 'main'
+./0002-test.c:10:5: warning[-Wanalyzer-double-free]: double-'free' of 'ptr'

--- a/tests/single-c/mem-basic-calloc/0004-calloc-plain-leak/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0004-calloc-plain-leak/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0004-test.c: scope_hint: In function 'main'
 ./0004-test.c:5:5: warning[-Wunused-result]: ignoring return value of 'calloc' declared with attribute 'warn_unused_result'
-#    5 |     calloc(1, sizeof(char)); /* leak */
-#      |     ^~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-calloc/0005-calloc-use-after-failure-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0005-calloc-use-after-failure-1/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./0005-test.c: scope_hint: In function 'main'
+./0005-test.c:6:10: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'ptr'

--- a/tests/single-c/mem-basic-calloc/0006-calloc-use-after-failure-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0006-calloc-use-after-failure-2/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0006-test.c: scope_hint: In function 'main'
+./0006-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-calloc/0007-calloc-use-after-free/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0007-calloc-use-after-free/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-416):
+./0007-test.c: scope_hint: In function 'main'
+./0007-test.c:11:10: warning[-Wanalyzer-use-after-free]: use after 'free' of 'ptr'

--- a/tests/single-c/mem-basic-calloc/0014-calloc-zerosize-use-null-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0014-calloc-zerosize-use-null-1/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0014-test.c: scope_hint: In function 'main'
+./0014-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-calloc/0015-calloc-zerosize-use-null-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0015-calloc-zerosize-use-null-2/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0015-test.c: scope_hint: In function 'main'
+./0015-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-calloc/0016-calloc-zerosize-use-null-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0016-calloc-zerosize-use-null-3/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0016-test.c: scope_hint: In function 'main'
+./0016-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-free/0001-free-bss/output-exp@gcc
+++ b/tests/single-c/mem-basic-free/0001-free-bss/output-exp@gcc
@@ -1,8 +1,7 @@
+Error: GCC_ANALYZER_WARNING (CWE-590):
+<built-in>: scope_hint: In function 'main'
+./0001-test.c:7:5: warning[-Wanalyzer-free-of-non-heap]: 'free' of '&a' which points to memory not on the heap
+
 Error: COMPILER_WARNING:
-./0001-test.c: scope_hint: In function 'main'
 ./0001-test.c:7:5: warning[-Wfree-nonheap-object]: 'free' called on unallocated object 'a'
-#    7 |     free(a); /* invalid free */
-#      |     ^~~~~~~
 ./0001-test.c:3:5: note: declared here
-#    3 | int a[10];
-#      |     ^

--- a/tests/single-c/mem-basic-free/0002-free-data/output-exp@gcc
+++ b/tests/single-c/mem-basic-free/0002-free-data/output-exp@gcc
@@ -1,8 +1,7 @@
+Error: GCC_ANALYZER_WARNING (CWE-590):
+<built-in>: scope_hint: In function 'main'
+./0002-test.c:7:5: warning[-Wanalyzer-free-of-non-heap]: 'free' of '&a' which points to memory not on the heap
+
 Error: COMPILER_WARNING:
-./0002-test.c: scope_hint: In function 'main'
 ./0002-test.c:7:5: warning[-Wfree-nonheap-object]: 'free' called on unallocated object 'a'
-#    7 |     free(a); /* invalid free */
-#      |     ^~~~~~~
 ./0002-test.c:3:5: note: declared here
-#    3 | int a[10] = { 42 };
-#      |     ^

--- a/tests/single-c/mem-basic-free/0004-free-numeric/output-exp@gcc
+++ b/tests/single-c/mem-basic-free/0004-free-numeric/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0004-test.c: scope_hint: In function 'main'
 ./0004-test.c:5:5: warning[-Wfree-nonheap-object]: 'free' called on a pointer to an unallocated object '57005'
-#    5 |     free((void *) 0xDEAD); /* invalid free */
-#      |     ^~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-free/0005-free-rodata/output-exp@gcc
+++ b/tests/single-c/mem-basic-free/0005-free-rodata/output-exp@gcc
@@ -1,5 +1,6 @@
+Error: GCC_ANALYZER_WARNING (CWE-590):
+<built-in>: scope_hint: In function 'main'
+./0005-test.c:5:5: warning[-Wanalyzer-free-of-non-heap]: 'free' of '"test"' which points to memory not on the heap
+
 Error: COMPILER_WARNING:
-./0005-test.c: scope_hint: In function 'main'
 ./0005-test.c:5:5: warning[-Wfree-nonheap-object]: 'free' called on a pointer to an unallocated object '"test"'
-#    5 |     free("test"); /* invalid free */
-#      |     ^~~~~~~~~~~~

--- a/tests/single-c/mem-basic-free/0006-free-stack/output-exp@gcc
+++ b/tests/single-c/mem-basic-free/0006-free-stack/output-exp@gcc
@@ -1,8 +1,7 @@
+Error: GCC_ANALYZER_WARNING (CWE-590):
+<built-in>: scope_hint: In function 'main'
+./0006-test.c:6:5: warning[-Wanalyzer-free-of-non-heap]: 'free' of '&a' which points to memory not on the heap
+
 Error: COMPILER_WARNING:
-./0006-test.c: scope_hint: In function 'main'
 ./0006-test.c:6:5: warning[-Wfree-nonheap-object]: 'free' called on unallocated object 'a'
-#    6 |     free(&a); /* invalid free */
-#      |     ^~~~~~~~
 ./0006-test.c:5:9: note: declared here
-#    5 |     int a;
-#      |         ^

--- a/tests/single-c/mem-basic-free/0007-free-text/output-exp@gcc
+++ b/tests/single-c/mem-basic-free/0007-free-text/output-exp@gcc
@@ -1,8 +1,4 @@
 Error: COMPILER_WARNING:
 ./0007-test.c: scope_hint: In function 'main'
 ./0007-test.c:5:5: warning[-Wfree-nonheap-object]: 'free' called on unallocated object 'main'
-#    5 |     free(main); /* invalid free */
-#      |     ^~~~~~~~~~
 ./0007-test.c:3:5: note: declared here
-#    3 | int main(void)
-#      |     ^~~~

--- a/tests/single-c/mem-basic-malloc/0002-malloc-doublefree/output-exp@gcc
+++ b/tests/single-c/mem-basic-malloc/0002-malloc-doublefree/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./0002-test.c: scope_hint: In function 'main'
+./0002-test.c:10:5: warning[-Wanalyzer-double-free]: double-'free' of 'ptr'

--- a/tests/single-c/mem-basic-malloc/0004-malloc-plain-leak/output-exp@gcc
+++ b/tests/single-c/mem-basic-malloc/0004-malloc-plain-leak/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0004-test.c: scope_hint: In function 'main'
 ./0004-test.c:5:5: warning[-Wunused-result]: ignoring return value of 'malloc' declared with attribute 'warn_unused_result'
-#    5 |     malloc(sizeof(char)); /* leak */
-#      |     ^~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-malloc/0005-malloc-use-after-failure-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-malloc/0005-malloc-use-after-failure-1/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./0005-test.c: scope_hint: In function 'main'
+./0005-test.c:6:10: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'ptr'

--- a/tests/single-c/mem-basic-malloc/0006-malloc-use-after-failure-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-malloc/0006-malloc-use-after-failure-2/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0006-test.c: scope_hint: In function 'main'
+./0006-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-malloc/0007-malloc-use-after-free/output-exp@gcc
+++ b/tests/single-c/mem-basic-malloc/0007-malloc-use-after-free/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-416):
+./0007-test.c: scope_hint: In function 'main'
+./0007-test.c:11:10: warning[-Wanalyzer-use-after-free]: use after 'free' of 'ptr'

--- a/tests/single-c/mem-basic-malloc/0010-malloc-zerosize-use-null/output-exp@gcc
+++ b/tests/single-c/mem-basic-malloc/0010-malloc-zerosize-use-null/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0010-test.c: scope_hint: In function 'main'
+./0010-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-realloc-as-malloc/0002-realloc-as-malloc-doublefree/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc-as-malloc/0002-realloc-as-malloc-doublefree/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./0002-test.c: scope_hint: In function 'main'
+./0002-test.c:10:5: warning[-Wanalyzer-double-free]: double-'free' of 'ptr'

--- a/tests/single-c/mem-basic-realloc-as-malloc/0004-realloc-as-malloc-plain-leak/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc-as-malloc/0004-realloc-as-malloc-plain-leak/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0004-test.c: scope_hint: In function 'main'
 ./0004-test.c:5:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-#    5 |     realloc(NULL, sizeof(char)); /* leak */
-#      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-realloc-as-malloc/0005-realloc-as-malloc-use-after-failure-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc-as-malloc/0005-realloc-as-malloc-use-after-failure-1/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./0005-test.c: scope_hint: In function 'main'
+./0005-test.c:6:10: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'ptr'

--- a/tests/single-c/mem-basic-realloc-as-malloc/0006-realloc-as-malloc-use-after-failure-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc-as-malloc/0006-realloc-as-malloc-use-after-failure-2/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0006-test.c: scope_hint: In function 'main'
+./0006-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-realloc-as-malloc/0007-realloc-as-malloc-use-after-free/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc-as-malloc/0007-realloc-as-malloc-use-after-free/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-416):
+./0007-test.c: scope_hint: In function 'main'
+./0007-test.c:11:10: warning[-Wanalyzer-use-after-free]: use after 'free' of 'ptr'

--- a/tests/single-c/mem-basic-realloc-as-malloc/0010-realloc-as-malloc-zerosize-use-null/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc-as-malloc/0010-realloc-as-malloc-zerosize-use-null/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./0010-test.c: scope_hint: In function 'main'
+./0010-test.c:7:14: warning[-Wanalyzer-null-dereference]: dereference of NULL 'ptr'

--- a/tests/single-c/mem-basic-realloc/0019-realloc-doublefree-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0019-realloc-doublefree-1/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./0019-test.c: scope_hint: In function 'main'
+./0019-test.c:16:5: warning[-Wanalyzer-double-free]: double-'free' of 'newptr'

--- a/tests/single-c/mem-basic-realloc/0020-realloc-doublefree-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0020-realloc-doublefree-2/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./0020-test.c: scope_hint: In function 'main'
+./0020-test.c:16:5: warning[-Wanalyzer-double-free]: double-'free' of 'newptr'

--- a/tests/single-c/mem-basic-realloc/0021-realloc-doublefree-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0021-realloc-doublefree-3/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./0021-test.c: scope_hint: In function 'main'
+./0021-test.c:16:5: warning[-Wanalyzer-double-free]: double-'free' of 'newptr'

--- a/tests/single-c/mem-basic-realloc/0022-realloc-doublefree-4/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0022-realloc-doublefree-4/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./0022-test.c: scope_hint: In function 'main'
+./0022-test.c:22:5: warning[-Wanalyzer-double-free]: double-'free' of 'ptr3'

--- a/tests/single-c/mem-basic-realloc/0032-realloc-invalid-ptr-nonheap-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0032-realloc-invalid-ptr-nonheap-1/output-exp@gcc
@@ -1,8 +1,4 @@
 Error: COMPILER_WARNING:
 ./0032-test.c: scope_hint: In function 'main'
 ./0032-test.c:6:17: warning[-Wfree-nonheap-object]: 'realloc' called on unallocated object 'a'
-#    6 |     void *ptr = realloc(&a, sizeof(char)); /* error */
-#      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
 ./0032-test.c:5:9: note: declared here
-#    5 |     int a;
-#      |         ^

--- a/tests/single-c/mem-basic-realloc/0033-realloc-invalid-ptr-nonheap-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0033-realloc-invalid-ptr-nonheap-2/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0033-test.c: scope_hint: In function 'main'
 ./0033-test.c:5:17: warning[-Wfree-nonheap-object]: 'realloc' called on a pointer to an unallocated object '"test"'
-#    5 |     void *ptr = realloc("test", sizeof(char)); /* error */
-#      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-realloc/0034-realloc-invalid-ptr-nonheap-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0034-realloc-invalid-ptr-nonheap-3/output-exp@gcc
@@ -1,8 +1,4 @@
 Error: COMPILER_WARNING:
 ./0034-test.c: scope_hint: In function 'main'
 ./0034-test.c:7:17: warning[-Wfree-nonheap-object]: 'realloc' called on unallocated object 'a'
-#    7 |     void *ptr = realloc(a, sizeof(char)); /* error */
-#      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
 ./0034-test.c:3:5: note: declared here
-#    3 | int a[10];
-#      |     ^

--- a/tests/single-c/mem-basic-realloc/0035-realloc-invalid-ptr-nonheap-4/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0035-realloc-invalid-ptr-nonheap-4/output-exp@gcc
@@ -1,8 +1,4 @@
 Error: COMPILER_WARNING:
 ./0035-test.c: scope_hint: In function 'main'
 ./0035-test.c:5:17: warning[-Wfree-nonheap-object]: 'realloc' called on unallocated object 'main'
-#    5 |     void *ptr = realloc(main, sizeof(char)); /* error */
-#      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 ./0035-test.c:3:5: note: declared here
-#    3 | int main(void)
-#      |     ^~~~

--- a/tests/single-c/mem-basic-realloc/0036-realloc-invalid-ptr-nonheap-5/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0036-realloc-invalid-ptr-nonheap-5/output-exp@gcc
@@ -1,8 +1,4 @@
 Error: COMPILER_WARNING:
 ./0036-test.c: scope_hint: In function 'main'
 ./0036-test.c:7:17: warning[-Wfree-nonheap-object]: 'realloc' called on unallocated object 'a'
-#    7 |     void *ptr = realloc(&a, sizeof(char)); /* error */
-#      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
 ./0036-test.c:3:5: note: declared here
-#    3 | int a = 5;
-#      |     ^

--- a/tests/single-c/mem-basic-realloc/0037-realloc-invalid-ptr-nonheap-6/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0037-realloc-invalid-ptr-nonheap-6/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0037-test.c: scope_hint: In function 'main'
 ./0037-test.c:5:17: warning[-Wfree-nonheap-object]: 'realloc' called on a pointer to an unallocated object '57005'
-#    5 |     void *ptr = realloc((void *) 0xDEAD, sizeof(char)); /* error */
-#      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-realloc/0042-realloc-plain-leak-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0042-realloc-plain-leak-1/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0042-test.c: scope_hint: In function 'main'
 ./0042-test.c:9:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-#    9 |     realloc(ptr, 2 * sizeof(char)); /* leak */
-#      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-realloc/0043-realloc-plain-leak-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0043-realloc-plain-leak-2/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0043-test.c: scope_hint: In function 'main'
 ./0043-test.c:9:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-#    9 |     realloc(ptr, 2 * sizeof(char)); /* leak */
-#      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-realloc/0044-realloc-plain-leak-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0044-realloc-plain-leak-3/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0044-test.c: scope_hint: In function 'main'
 ./0044-test.c:9:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-#    9 |     realloc(ptr, 2 * sizeof(char)); /* leak */
-#      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-realloc/0045-realloc-plain-leak-4/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0045-realloc-plain-leak-4/output-exp@gcc
@@ -1,5 +1,3 @@
 Error: COMPILER_WARNING:
 ./0045-test.c: scope_hint: In function 'main'
 ./0045-test.c:15:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-#   15 |     realloc(ptr2, 3 * sizeof(char)); /* leak */
-#      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/single-c/mem-basic-realloc/0055-realloc-use-after-free-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0055-realloc-use-after-free-1/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-416):
+./0055-test.c: scope_hint: In function 'main'
+./0055-test.c:17:10: warning[-Wanalyzer-use-after-free]: use after 'free' of 'ptr2'

--- a/tests/single-c/mem-basic-realloc/0056-realloc-use-after-free-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0056-realloc-use-after-free-2/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-416):
+./0056-test.c: scope_hint: In function 'main'
+./0056-test.c:17:10: warning[-Wanalyzer-use-after-free]: use after 'free' of 'ptr2'

--- a/tests/single-c/mem-basic-realloc/0057-realloc-use-after-free-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0057-realloc-use-after-free-3/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-416):
+./0057-test.c: scope_hint: In function 'main'
+./0057-test.c:17:10: warning[-Wanalyzer-use-after-free]: use after 'free' of 'ptr2'

--- a/tests/single-c/mem-basic-realloc/0058-realloc-use-after-free-4/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0058-realloc-use-after-free-4/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-416):
+./0058-test.c: scope_hint: In function 'main'
+./0058-test.c:23:10: warning[-Wanalyzer-use-after-free]: use after 'free' of 'ptr3'

--- a/tests/single-c/output-convert.sh@gcc
+++ b/tests/single-c/output-convert.sh@gcc
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec csgrep --prune=1

--- a/tests/single-c/output-diff.sh@gcc
+++ b/tests/single-c/output-diff.sh@gcc
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec diff -up <(cssort "$1") <(cssort "$2")

--- a/tests/single-c/predator/fwnull-0001/fwnull-0001.c
+++ b/tests/single-c/predator/fwnull-0001/fwnull-0001.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-void test0(void) {
+static void test0(void) {
     void **x = NULL;
     *x = (void *)&x;
 }

--- a/tests/single-c/predator/fwnull-0001/output-exp@gcc
+++ b/tests/single-c/predator/fwnull-0001/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./fwnull-0001.c: scope_hint: In function 'test0'
+./fwnull-0001.c:5:8: warning[-Wanalyzer-null-dereference]: dereference of NULL '0'

--- a/tests/single-c/predator/predator-regre-test-0002/output-exp@gcc
+++ b/tests/single-c/predator/predator-regre-test-0002/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-476):
+./test-0002.c: scope_hint: In function 'main'
+./test-0002.c:12:12: warning[-Wanalyzer-null-dereference]: dereference of NULL 'null_value'

--- a/tests/single-c/predator/predator-regre-test-0003/output-exp@gcc
+++ b/tests/single-c/predator/predator-regre-test-0003/output-exp@gcc
@@ -1,8 +1,10 @@
-Error: COMPILER_WARNING:
+Error: GCC_ANALYZER_WARNING (CWE-590):
 ./test-0003.c: scope_hint: In function 'main'
+./test-0003.c:20:13: warning[-Wanalyzer-free-of-non-heap]: 'free' of 'ptr' which points to memory not on the heap
+
+Error: GCC_ANALYZER_WARNING (CWE-415):
+./test-0003.c:29:5: warning[-Wanalyzer-double-free]: double-'free' of 'item'
+
+Error: COMPILER_WARNING:
 ./test-0003.c:20:13: warning[-Wfree-nonheap-object]: 'free' called on unallocated object 'val'
-#   20 |             free(ptr);
-#      |             ^~~~~~~~~
 ./test-0003.c:7:11: note: declared here
-#    7 |     void *val = NULL;
-#      |           ^~~

--- a/tests/single-c/predator/predator-regre-test-0005/output-exp@gcc
+++ b/tests/single-c/predator/predator-regre-test-0005/output-exp@gcc
@@ -1,0 +1,6 @@
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0005.c: scope_hint: In function 'main'
+./test-0005.c:7:11: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'list'
+
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0005.c:8:24: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL '*list'

--- a/tests/single-c/predator/predator-regre-test-0006/output-exp@gcc
+++ b/tests/single-c/predator/predator-regre-test-0006/output-exp@gcc
@@ -1,0 +1,6 @@
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0006.c: scope_hint: In function 'main'
+./test-0006.c:20:11: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'list'
+
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0006.c:21:24: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL '*list'

--- a/tests/single-c/predator/predator-regre-test-0008/output-exp@gcc
+++ b/tests/single-c/predator/predator-regre-test-0008/output-exp@gcc
@@ -1,0 +1,18 @@
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0008.c: scope_hint: In function 'test'
+./test-0008.c:28:11: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'list'
+
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0008.c:32:11: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'list'
+
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0008.c:33:24: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL '*list'
+
+Error: GCC_ANALYZER_WARNING (CWE-401):
+./test-0008.c:35:1: warning[-Wanalyzer-malloc-leak]: leak of 'list'
+
+Error: GCC_ANALYZER_WARNING (CWE-401):
+./test-0008.c:35:1: warning[-Wanalyzer-malloc-leak]: leak of '<unknown>'
+
+Error: GCC_ANALYZER_WARNING (CWE-401):
+./test-0008.c:35:1: warning[-Wanalyzer-malloc-leak]: leak of 'list'

--- a/tests/single-c/predator/predator-regre-test-0009/output-exp@gcc
+++ b/tests/single-c/predator/predator-regre-test-0009/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-690):
+./test-0009.c: scope_hint: In function 'main'
+./test-0009.c:15:10: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'err'


### PR DESCRIPTION
Instead of checking for `gcc -fanalyzer` explicitly, we expect it
to be always available when GCC's major version is 11 or higher.

The option `-fno-diagnostics-show-caret` applies to all diagnostic
messages coming from gcc.  So it resulted in missing comments also
in the existing COMPILER_WARNING reports.