### PR TITLE
CI: Remove Fedora 32

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # Fedora release targets
-        release: [32, 33, 34, rawhide]
+        release: [33, 34, rawhide]
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Fedora 32 EOL was on 25th May.