### PR TITLE
symbiotic: Execute with --require-slicer

### DIFF
--- a/tests/single-c/args-prefix@symbiotic
+++ b/tests/single-c/args-prefix@symbiotic
@@ -1,1 +1,1 @@
---prp=memsafety
+--require-slicer --prp=memsafety


### PR DESCRIPTION
so that we can report crashes in the slicer to the Symbiotic team.
Up to this point if slicing failed, Symbiotic would execute KLEE on the
unsliced bitcode.