### PR TITLE
CI: Run CI only on pushes and PRs to main

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -2,7 +2,11 @@
 name: Fedora CI
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 10 * * 1'
 


### PR DESCRIPTION
... so that we do not waste GitHub's computing power.