### PR TITLE
symbiotic: execute with `--debug=all`

### DIFF
--- a/tests/single-c/args-prefix@symbiotic
+++ b/tests/single-c/args-prefix@symbiotic
@@ -1,1 +1,1 @@
---require-slicer --prp=memsafety
+--require-slicer --prp=memsafety --debug=all


### PR DESCRIPTION
.. to have `sys.argv` in the output.

See: staticafi/symbiotic#195