### PR TITLE
ci: enable updates-testing repositories and Fedora 35

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # Fedora release targets
-        release: [33, 34, rawhide]
+        release: [33, 34, 35, rawhide]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Update the system and install dependencies
         run: |
+          dnf config-manager --set-enabled updates-testing
+          dnf config-manager --set-enabled updates-testing-modular
           dnf update -y
           DNF_OPTS=-y make install-deps
 


### PR DESCRIPTION
... so that we can get package updates faster.