### PR TITLE
use COPRs from the `aufover` group

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -31,13 +31,13 @@ jobs:
       - name: Install Copr support and make
         run: dnf install dnf-plugins-core make -y
 
-      - name: Enable given copr repositories
+      - name: Enable AUFOVER copr repositories
         run: |
-          dnf copr enable -y lzaoral/Divine
-          dnf copr enable -y kdudka/csdiff
-          dnf copr enable -y kdudka/predator
+          dnf copr enable -y @aufover/csdiff
+          dnf copr enable -y @aufover/divine
+          dnf copr enable -y @aufover/predator
           if [[ ! -v NO_SYMBIOTIC ]]; then
-            dnf copr enable jamartis/symbiotic -y
+            dnf copr enable -y @aufover/symbiotic
           fi
 
       - name: Update the system and install dependencies

--- a/README
+++ b/README
@@ -7,10 +7,11 @@ cppcheck).
 
 How to run existing tests?
 --------------------------
-- enable yum/dnf repositories from the following coprs:
-    https://copr.fedorainfracloud.org/coprs/lzaoral/Divine/
-    https://copr.fedorainfracloud.org/coprs/jamartis/symbiotic/
-    https://copr.fedorainfracloud.org/coprs/kdudka/predator/
+- enable yum/dnf repositories from `aufover` COPRs:
+    $ sudo dnf copr enable -y @aufover/csdiff
+    $ sudo dnf copr enable -y @aufover/divine
+    $ sudo dnf copr enable -y @aufover/predator
+    $ sudo dnf copr enable -y @aufover/symbiotic
 
 - install required/optional dependencies of the benchmark on the system:
     $ make install-deps


### PR DESCRIPTION
... rather than mix of personal COPRs of individual contributors