### PR TITLE
clang13: do not depend on exact contents of standard C headers

### DIFF
--- a/tests/single-c/mem-basic-realloc/0005-realloc-after-failure-nonfreed-1/output-diff.sh@clang
+++ b/tests/single-c/mem-basic-realloc/0005-realloc-after-failure-nonfreed-1/output-diff.sh@clang
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec csdiff "$@"

--- a/tests/single-c/mem-basic-realloc/0006-realloc-after-failure-nonfreed-2/output-diff.sh@clang
+++ b/tests/single-c/mem-basic-realloc/0006-realloc-after-failure-nonfreed-2/output-diff.sh@clang
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec csdiff "$@"

--- a/tests/single-c/mem-basic-realloc/0007-realloc-after-failure-nonfreed-3/output-diff.sh@clang
+++ b/tests/single-c/mem-basic-realloc/0007-realloc-after-failure-nonfreed-3/output-diff.sh@clang
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec csdiff "$@"

--- a/tests/single-c/mem-basic-realloc/0008-realloc-after-failure-nonfreed-4/output-diff.sh@clang
+++ b/tests/single-c/mem-basic-realloc/0008-realloc-after-failure-nonfreed-4/output-diff.sh@clang
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec csdiff "$@"


### PR DESCRIPTION
Should fix `clang` output differences in Rawhide.