### PR TITLE
single-c: update expected output for `gcc-12 -fanalyzer`

### DIFF
--- a/tests/single-c/mem-basic-realloc/0042-realloc-plain-leak-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0042-realloc-plain-leak-1/output-exp@gcc
@@ -1,6 +1,3 @@
 Error: COMPILER_WARNING:
 ./0042-test.c: scope_hint: In function 'main'
 ./0042-test.c:9:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-
-Error: GCC_ANALYZER_WARNING (CWE-401):
-<built-in>: warning[-Wanalyzer-malloc-leak]: leak of '<unknown>'

--- a/tests/single-c/mem-basic-realloc/0043-realloc-plain-leak-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0043-realloc-plain-leak-2/output-exp@gcc
@@ -1,6 +1,3 @@
 Error: COMPILER_WARNING:
 ./0043-test.c: scope_hint: In function 'main'
 ./0043-test.c:9:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-
-Error: GCC_ANALYZER_WARNING (CWE-401):
-<built-in>: warning[-Wanalyzer-malloc-leak]: leak of '<unknown>'

--- a/tests/single-c/mem-basic-realloc/0044-realloc-plain-leak-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0044-realloc-plain-leak-3/output-exp@gcc
@@ -1,6 +1,3 @@
 Error: COMPILER_WARNING:
 ./0044-test.c: scope_hint: In function 'main'
 ./0044-test.c:9:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-
-Error: GCC_ANALYZER_WARNING (CWE-401):
-<built-in>: warning[-Wanalyzer-malloc-leak]: leak of '<unknown>'

--- a/tests/single-c/mem-basic-realloc/0045-realloc-plain-leak-4/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0045-realloc-plain-leak-4/output-exp@gcc
@@ -1,6 +1,3 @@
 Error: COMPILER_WARNING:
 ./0045-test.c: scope_hint: In function 'main'
 ./0045-test.c:15:5: warning[-Wunused-result]: ignoring return value of 'realloc' declared with attribute 'warn_unused_result'
-
-Error: GCC_ANALYZER_WARNING (CWE-401):
-<built-in>: warning[-Wanalyzer-malloc-leak]: leak of '<unknown>'

--- a/tests/single-c/mem-overlap/memcpy-0002/args-prefix@gcc
+++ b/tests/single-c/mem-overlap/memcpy-0002/args-prefix@gcc
@@ -1,1 +1,0 @@
--fanalyzer -fdiagnostics-path-format=separate-events -fno-diagnostics-show-caret -c -fno-builtin-memcpy

--- a/tests/single-c/mem-overlap/memcpy-0002/output-exp@gcc
+++ b/tests/single-c/mem-overlap/memcpy-0002/output-exp@gcc
@@ -1,0 +1,3 @@
+Error: GCC_ANALYZER_WARNING (CWE-457):
+./test-0002.c: scope_hint: In function 'main'
+./test-0002.c:6:5: warning[-Wanalyzer-use-of-uninitialized-value]: use of uninitialized value '*(short unsigned int *)&arr + 1'

--- a/tests/single-c/mem-overlap/memmove-0009/args-prefix@gcc
+++ b/tests/single-c/mem-overlap/memmove-0009/args-prefix@gcc
@@ -1,1 +1,0 @@
--fanalyzer -fdiagnostics-path-format=separate-events -fno-diagnostics-show-caret -c -fno-builtin-memmove

--- a/tests/single-c/mem-overlap/memmove-0009/output-exp@gcc
+++ b/tests/single-c/mem-overlap/memmove-0009/output-exp@gcc
@@ -1,0 +1,4 @@
+Error: GCC_ANALYZER_WARNING (CWE-457):
+./test-0009.c:1: included_from: Included from here.
+./test-0009.c: scope_hint: In function 'main'
+./test-0009.c:7:12: warning[-Wanalyzer-use-of-uninitialized-value]: use of uninitialized value '*(short unsigned int *)&str1 + 1'


### PR DESCRIPTION
and remove work around for mem-overlap/mem{cpy-0002,move-0009}
because [gcc-12 bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104308) was (partially) fixed.

There is new(?) problem with `mem-overlap/memcpy-0001`:

```console
$ gcc -fanalyzer -fdiagnostics-path-format=separate-events -fno-diagnostics-show-caret -c ./test-000[root@fed36 gcc]# gcc -fanalyzer -fdiagnostics-path-format=separate-events -fno-diagnostics-show-caret -c ./test-0001.c
In function 'main':
cc1: warning: use of uninitialized value '*(unsigned char (*)[5])(&arr2[0])' [CWE-457] [-Wanalyzer-use-of-uninitialized-value]
./test-0001.c:7:10: note: (1) region created on stack here
cc1: note: (2) use of uninitialized value '*(unsigned char (*)[5])(&arr2[0])' here

$ ./cmd-convert.sh < ./output-raw.txt > ./log.txt # output-raw.txt contains output from command above
-:1: error: invalid syntax
```

we should consider reopening [gcc-12 bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104308).
