### PR TITLE
Revert "CI: disable `symbiotic` in Fedora 36 and higher"

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -36,10 +36,7 @@ jobs:
           dnf copr enable -y @aufover/csdiff
           dnf copr enable -y @aufover/divine
           dnf copr enable -y @aufover/predator
-
-      - name: Symbiotic does not support LLVM 14
-        if: matrix.release <= 35
-        run: dnf copr enable -y @aufover/symbiotic
+          dnf copr enable -y @aufover/symbiotic
 
       - name: Update the system and install dependencies
         run: |
@@ -56,10 +53,8 @@ jobs:
           done
 
           # benchmark requires CLANG 14+ and GCC 12+
-          # symbiotic does not support LLVM 14
           case "${{matrix.release}}" in
             3[45])
-              grep TOOL_ENABLE_symbiotic workdir/CMakeCache.txt
               ;;
             *)
               grep TOOL_ENABLE_clang workdir/CMakeCache.txt


### PR DESCRIPTION
This reverts commit 61acd9e3e7d585805d4fc2bdfa2752db6540e780.