### PR TITLE
CI: disable Symbiotic on Fedora 37+ 

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -35,7 +35,9 @@ jobs:
         run: |
           dnf copr enable -y @aufover/divine
           dnf copr enable -y @aufover/predator
-          dnf copr enable -y @aufover/symbiotic
+          if [[ "${{matrix.release}}" =~ 3[56] ]]; then
+            dnf copr enable -y @aufover/symbiotic
+          fi
 
       - name: Update the system and install dependencies
         run: |
@@ -47,13 +49,14 @@ jobs:
       - name: Check that all expected tools are present and working
         run: |
           make configure
-          for tool in cbmc cppcheck divine predator symbiotic; do
+          for tool in cbmc cppcheck divine predator; do
             grep TOOL_ENABLE_${tool} workdir/CMakeCache.txt
           done
 
           # benchmark requires CLANG 14+ and GCC 12+
           case "${{matrix.release}}" in
-            35)
+            3[56])
+              grep TOOL_ENABLE_symbiotic workdir/CMakeCache.txt
               ;;
             *)
               grep TOOL_ENABLE_clang workdir/CMakeCache.txt

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -33,7 +33,6 @@ jobs:
 
       - name: Enable AUFOVER copr repositories
         run: |
-          dnf copr enable -y @aufover/csdiff
           dnf copr enable -y @aufover/divine
           dnf copr enable -y @aufover/predator
           dnf copr enable -y @aufover/symbiotic


### PR DESCRIPTION
Unfortunately, Symbiotic cannot be ported to LLVM 15 without rather substantial rewrites so Fedora 36 will be the last version "officially" supported.  (Unless, there's someone else bored enough to do all the required work.)