### PR TITLE
gcc13 analyzer features

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           dnf copr enable -y @aufover/divine
           dnf copr enable -y @aufover/predator
-          if [[ "${{matrix.release}}" =~ 3[56] ]]; then
+          if [[ "${{matrix.release}}" =~ 36 ]]; then
             dnf copr enable -y @aufover/symbiotic
           fi
 
@@ -55,8 +55,11 @@ jobs:
 
           # benchmark requires CLANG 14+ and GCC 12+
           case "${{matrix.release}}" in
-            3[56])
+            36)
               grep TOOL_ENABLE_symbiotic workdir/CMakeCache.txt
+              ;;
+            37)
+              grep TOOL_ENABLE_clang workdir/CMakeCache.txt
               ;;
             *)
               grep TOOL_ENABLE_clang workdir/CMakeCache.txt

--- a/tests/find-tools.cmake
+++ b/tests/find-tools.cmake
@@ -34,7 +34,7 @@ set(TOOL_EXEC_predator "${TOOL_EXEC_gcc} -fplugin=predator"
     CACHE STRING "command used to run predator")
 
 # minimum required version of gcc (to avoid special-casing old versions of gcc)
-set(gcc_min_version 12)
+set(gcc_min_version 13)
 
 # command that returns major version number of the specified gcc executable
 set(gcc_version_cmd "echo __GNUC__ | ${TOOL_EXEC_gcc} -E - | tail -1")

--- a/tests/single-c/arrays-and-loops/reverse-array-bad-0006/README@gcc
+++ b/tests/single-c/arrays-and-loops/reverse-array-bad-0006/README@gcc
@@ -1,3 +1,7 @@
+The test is disabled, because gcc 13 brought a false positive.
+It was reported to upstream https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108598
+The first error here is new false positive, 3 following errors are new true positives.
+
 Error: GCC_ANALYZER_WARNING (CWE-121):
 ./test-0006.c: scope_hint: In function 'main'
 ./test-0006.c:20:25: warning[-Wanalyzer-out-of-bounds]: stack-based buffer overflow

--- a/tests/single-c/arrays-and-loops/reverse-array-bad-0006/output-exp@gcc
+++ b/tests/single-c/arrays-and-loops/reverse-array-bad-0006/output-exp@gcc
@@ -1,0 +1,18 @@
+Error: GCC_ANALYZER_WARNING (CWE-121):
+./test-0006.c: scope_hint: In function 'main'
+./test-0006.c:20:25: warning[-Wanalyzer-out-of-bounds]: stack-based buffer overflow
+/usr/include/stdlib.h:587: included_from: Included from here.
+./test-0006.c:1: included_from: Included from here.
+./test-0006.c:20:25: note: write of 4 bytes to beyond the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-126):
+./test-0006.c:24:23: warning[-Wanalyzer-out-of-bounds]: stack-based buffer over-read
+./test-0006.c:24:23: note: read of 4 bytes from after the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-126):
+./test-0006.c:26:14: warning[-Wanalyzer-out-of-bounds]: stack-based buffer over-read
+./test-0006.c:26:14: note: read of 4 bytes from after the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-121):
+./test-0006.c:27:12: warning[-Wanalyzer-out-of-bounds]: stack-based buffer overflow
+./test-0006.c:27:12: note: write of 4 bytes to beyond the end of the region

--- a/tests/single-c/mem-basic-calloc/0017-calloc-zerosize-use-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0017-calloc-zerosize-use-1/output-exp@gcc
@@ -1,0 +1,4 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0017-test.c: scope_hint: In function 'main'
+./0017-test.c:9:10: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0017-test.c:9:10: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-calloc/0018-calloc-zerosize-use-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0018-calloc-zerosize-use-2/output-exp@gcc
@@ -1,0 +1,4 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0018-test.c: scope_hint: In function 'main'
+./0018-test.c:9:10: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0018-test.c:9:10: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-calloc/0019-calloc-zerosize-use-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-calloc/0019-calloc-zerosize-use-3/output-exp@gcc
@@ -1,0 +1,4 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0019-test.c: scope_hint: In function 'main'
+./0019-test.c:9:10: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0019-test.c:9:10: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-malloc/0011-malloc-zerosize-use/output-exp@gcc
+++ b/tests/single-c/mem-basic-malloc/0011-malloc-zerosize-use/output-exp@gcc
@@ -1,0 +1,4 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0011-test.c: scope_hint: In function 'main'
+./0011-test.c:9:10: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0011-test.c:9:10: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-realloc-as-malloc/0011-realloc-as-malloc-zerosize-use/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc-as-malloc/0011-realloc-as-malloc-zerosize-use/output-exp@gcc
@@ -1,0 +1,4 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0011-test.c: scope_hint: In function 'main'
+./0011-test.c:9:10: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0011-test.c:9:10: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-realloc/0080-realloc-zerosize-use-1/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0080-realloc-zerosize-use-1/output-exp@gcc
@@ -1,0 +1,9 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0080-test.c: scope_hint: In function 'main'
+./0080-test.c:20:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0080-test.c:1: included_from: Included from here.
+./0080-test.c:20:11: note: write of 1 byte to beyond the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0080-test.c:20:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0080-test.c:20:11: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-realloc/0081-realloc-zerosize-use-2/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0081-realloc-zerosize-use-2/output-exp@gcc
@@ -1,0 +1,9 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0081-test.c: scope_hint: In function 'main'
+./0081-test.c:20:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0081-test.c:1: included_from: Included from here.
+./0081-test.c:20:11: note: write of 1 byte to beyond the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0081-test.c:20:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0081-test.c:20:11: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-realloc/0082-realloc-zerosize-use-3/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0082-realloc-zerosize-use-3/output-exp@gcc
@@ -1,0 +1,9 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0082-test.c: scope_hint: In function 'main'
+./0082-test.c:20:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0082-test.c:1: included_from: Included from here.
+./0082-test.c:20:11: note: write of 1 byte to beyond the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0082-test.c:20:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0082-test.c:20:11: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/mem-basic-realloc/0083-realloc-zerosize-use-4/output-exp@gcc
+++ b/tests/single-c/mem-basic-realloc/0083-realloc-zerosize-use-4/output-exp@gcc
@@ -1,0 +1,9 @@
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0083-test.c: scope_hint: In function 'main'
+./0083-test.c:26:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0083-test.c:1: included_from: Included from here.
+./0083-test.c:26:11: note: write of 1 byte to beyond the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./0083-test.c:26:11: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./0083-test.c:26:11: note: write of 1 byte to beyond the end of the region

--- a/tests/single-c/predator/predator-regre-test-0009/output-exp@gcc
+++ b/tests/single-c/predator/predator-regre-test-0009/output-exp@gcc
@@ -1,3 +1,10 @@
-Error: GCC_ANALYZER_WARNING (CWE-690):
+Error: GCC_ANALYZER_WARNING (CWE-131):
 ./test-0009.c: scope_hint: In function 'main'
+./test-0009.c:12:12: warning[-Wanalyzer-allocation-size]: allocated buffer size is not a multiple of the pointee's size
+
+Error: GCC_ANALYZER_WARNING (CWE-122):
+./test-0009.c:15:10: warning[-Wanalyzer-out-of-bounds]: heap-based buffer overflow
+./test-0009.c:15:10: note: write of 7 bytes to beyond the end of the region
+
+Error: GCC_ANALYZER_WARNING (CWE-690):
 ./test-0009.c:15:10: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'err'


### PR DESCRIPTION
Updating results for gcc.
Disabling gcc for fedora <=37, as there are different results.

Mostly it seems to be true positives, but I see one possibly false positive:


```
[tests/single-c/arrays-and-loops/reverse-array-bad-0006/output-exp@gcc](https://github.com/aufover/aufover-benchmark/compare/main...psimovec:aufover-benchmark:gcc13-analyzer-features?expand=1#diff-43cb62b30618634eb28b7ca4454dfa4b0aed03cddf4b06e1a5e8ea66e0718d66)
@@ -0,0 +1,18 @@
Error: GCC_ANALYZER_WARNING (CWE-121):
./test-0006.c: scope_hint: In function 'main'
./test-0006.c:20:25: warning[-Wanalyzer-out-of-bounds]: stack-based buffer overflow
/usr/include/stdlib.h:587: included_from: Included from here.
./test-0006.c:1: included_from: Included from here.
./test-0006.c:20:25: note: write of 4 bytes to beyond the end of the region
```

here
``` c
    ...
    int length = 99;

    int *arr = alloca(length);

    for (int i = 0; i < length; i++) {
        arr[i] = __VERIFIER_nondet_int();
    }

    for (int i = 0; i < length; i++) {
        if (arr[i] == '\0')
            arr[i]++;
    }

    arr[length / 2 + 1] = '\0';  // <--------
    ...
```

It seems to me that there is no problem on this line.