### PR TITLE
Add new clang15 outputs

### DIFF
--- a/tests/single-c/mem-basic-realloc/0032-realloc-invalid-ptr-nonheap-1/output-exp@clang
+++ b/tests/single-c/mem-basic-realloc/0032-realloc-invalid-ptr-nonheap-1/output-exp@clang
@@ -1,0 +1,15 @@
+Error: CLANG_WARNING:
+./0032-test.c:6:11: warning: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~
+./0032-test.c:6:11: note: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Error: CLANG_WARNING:
+./0032-test.c:6:17: warning: Argument to realloc() is the address of the local variable 'a', which is not memory allocated by malloc()
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#                ^       ~~
+./0032-test.c:6:17: note: Argument to realloc() is the address of the local variable 'a', which is not memory allocated by malloc()
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#                ^       ~~

--- a/tests/single-c/mem-basic-realloc/0033-realloc-invalid-ptr-nonheap-2/output-exp@clang
+++ b/tests/single-c/mem-basic-realloc/0033-realloc-invalid-ptr-nonheap-2/output-exp@clang
@@ -1,0 +1,15 @@
+Error: CLANG_WARNING:
+./0033-test.c:5:11: warning: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc("test", sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./0033-test.c:5:11: note: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc("test", sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Error: CLANG_WARNING:
+./0033-test.c:5:17: warning: Argument to realloc() is the address of a global variable, which is not memory allocated by malloc()
+#    void *ptr = realloc("test", sizeof(char)); /* error */
+#                ^       ~~~~~~
+./0033-test.c:5:17: note: Argument to realloc() is the address of a global variable, which is not memory allocated by malloc()
+#    void *ptr = realloc("test", sizeof(char)); /* error */
+#                ^       ~~~~~~

--- a/tests/single-c/mem-basic-realloc/0034-realloc-invalid-ptr-nonheap-3/output-exp@clang
+++ b/tests/single-c/mem-basic-realloc/0034-realloc-invalid-ptr-nonheap-3/output-exp@clang
@@ -1,0 +1,15 @@
+Error: CLANG_WARNING:
+./0034-test.c:7:11: warning: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(a, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~
+./0034-test.c:7:11: note: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(a, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~
+
+Error: CLANG_WARNING:
+./0034-test.c:7:17: warning: Argument to realloc() is the address of the global variable 'a', which is not memory allocated by malloc()
+#    void *ptr = realloc(a, sizeof(char)); /* error */
+#                ^       ~
+./0034-test.c:7:17: note: Argument to realloc() is the address of the global variable 'a', which is not memory allocated by malloc()
+#    void *ptr = realloc(a, sizeof(char)); /* error */
+#                ^       ~

--- a/tests/single-c/mem-basic-realloc/0035-realloc-invalid-ptr-nonheap-4/output-exp@clang
+++ b/tests/single-c/mem-basic-realloc/0035-realloc-invalid-ptr-nonheap-4/output-exp@clang
@@ -1,0 +1,15 @@
+Error: CLANG_WARNING:
+./0035-test.c:5:11: warning: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(main, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./0035-test.c:5:11: note: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(main, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Error: CLANG_WARNING:
+./0035-test.c:5:17: warning: Argument to realloc() is the address of the function 'main', which is not memory allocated by malloc()
+#    void *ptr = realloc(main, sizeof(char)); /* error */
+#                ^       ~~~~
+./0035-test.c:5:17: note: Argument to realloc() is the address of the function 'main', which is not memory allocated by malloc()
+#    void *ptr = realloc(main, sizeof(char)); /* error */
+#                ^       ~~~~

--- a/tests/single-c/mem-basic-realloc/0036-realloc-invalid-ptr-nonheap-5/output-exp@clang
+++ b/tests/single-c/mem-basic-realloc/0036-realloc-invalid-ptr-nonheap-5/output-exp@clang
@@ -1,0 +1,15 @@
+Error: CLANG_WARNING:
+./0036-test.c:7:11: warning: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~
+./0036-test.c:7:11: note: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Error: CLANG_WARNING:
+./0036-test.c:7:17: warning: Argument to realloc() is the address of the global variable 'a', which is not memory allocated by malloc()
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#                ^       ~~
+./0036-test.c:7:17: note: Argument to realloc() is the address of the global variable 'a', which is not memory allocated by malloc()
+#    void *ptr = realloc(&a, sizeof(char)); /* error */
+#                ^       ~~

--- a/tests/single-c/mem-basic-realloc/0037-realloc-invalid-ptr-nonheap-6/output-exp@clang
+++ b/tests/single-c/mem-basic-realloc/0037-realloc-invalid-ptr-nonheap-6/output-exp@clang
@@ -1,0 +1,15 @@
+Error: CLANG_WARNING:
+./0037-test.c:5:11: warning: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc((void *) 0xDEAD, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./0037-test.c:5:11: note: Value stored to 'ptr' during its initialization is never read
+#    void *ptr = realloc((void *) 0xDEAD, sizeof(char)); /* error */
+#          ^~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Error: CLANG_WARNING:
+./0037-test.c:5:17: warning: Argument to realloc() is a constant address (57005), which is not memory allocated by malloc()
+#    void *ptr = realloc((void *) 0xDEAD, sizeof(char)); /* error */
+#                ^       ~~~~~~~~~~~~~~~
+./0037-test.c:5:17: note: Argument to realloc() is a constant address (57005), which is not memory allocated by malloc()
+#    void *ptr = realloc((void *) 0xDEAD, sizeof(char)); /* error */
+#                ^       ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Resolves #32 

Clang has some non-empty output in tests/single-c/mem-basic-realloc

    0032-0037 clang gets TP right, I should add these test cases
    0063 to 0067 false positives, seems to not understand errno
    0076-0079 FP, does not understand errno again, FN - misses the real problem
    0080-0083 the same FP as in previous tests, but this time clang gets the TP right
