### PR TITLE
CI: use official Fedora images from registry.fedoraproject.org

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -21,7 +21,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: fedora:${{matrix.release}}
+      image: registry.fedoraproject.org/fedora:${{matrix.release}}
       options: --security-opt seccomp=unconfined
 
     steps:


### PR DESCRIPTION
They seem to be more up-to-date than the images in Docker Hub.